### PR TITLE
feat: makeStyles -> make output more type safe

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -3,7 +3,7 @@
 , name =
     "react-basic-mui"
 , dependencies =
-    [ "debug", "react-basic-hooks", "simple-json", "spec", "unsafe-reference" ]
+    [ "debug", "react-basic-hooks", "simple-json", "spec", "unsafe-reference", "typelevel-prelude" ]
 , packages =
     ./packages.dhall
 }

--- a/src/MUI/Core/Styles/MakeStyles.purs
+++ b/src/MUI/Core/Styles/MakeStyles.purs
@@ -1,9 +1,39 @@
 module MUI.Core.Styles.MakeStyles where
 
+import Prelude
+import Type.Row
+import Type.RowList
+
 import Foreign.Object (Object)
 import MUI.Core (JSS)
 import MUI.Core.Styles.CreateMuiTheme (Theme)
 import React.Basic.Hooks (Hook)
 
 foreign import data UseStyles :: Type -> Type
-foreign import makeStyles :: (Theme -> JSS) -> Hook UseStyles (Object String)
+
+foreign import makeStyles :: forall input output. MapRecordValuesToString input output => (Theme -> Record input) -> Hook UseStyles (Record output)
+
+class MapRecordValuesToString
+  (input_row :: # Type)
+  (output_row :: # Type)
+
+instance mapRecordValuesToString
+  :: ( RowToList input_row input_rowList
+     , MapRecordValuesToStringImpl input_rowList output_rowList
+     , ListToRow output_rowList output_row
+     )
+  => MapRecordValuesToString input_row output_row
+
+class MapRecordValuesToStringImpl
+  (input_rowList :: RowList)
+  (output_rowList :: RowList)
+  | input_rowList -> output_rowList
+
+instance mapRecordValuesToStringImplNil ::
+  MapRecordValuesToStringImpl Nil Nil
+
+instance mapRecordValuesToStringImplCons ::
+  (MapRecordValuesToStringImpl input_tail output_tail)
+  => MapRecordValuesToStringImpl
+  (Cons input_symbol input_fieldType input_tail)
+  (Cons input_symbol String output_tail)


### PR DESCRIPTION
example usage

```
useStyles :: Hook UseStyles ({ mygrid :: String })
useStyles =
  MUI.Core.Styles.MakeStyles.makeStyles
    $ \theme ->
        { mygrid:
          { width: "50%"
          }
        }
mkPage :: Effect (ReactComponent Props)
mkPage = component "registration" \props -> React.do
  classes <- useStyles

  pure $ MUI.Core.Grid.grid
    { container: true
    , className: classes.mygrid

...
```